### PR TITLE
Curl removal and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ And then execute:
 
 ## Usage
 
-**Note:** Currently requires `curl` to be present on the server for notifications to be sent.  Patches happily accepted to improve this limitation!
-
     require 'mina/rollbar'
 
     ...
@@ -41,14 +39,13 @@ And then execute:
 
 ## Options
 
-| Name                         | Description                                        |
-| ---------------------------- | -------------------------------------------------- |
-| `rollbar_access_token`       | Rollbar access token (post_server_item token)      |
-| `rollbar_username`           | Rollbar username of deploying user (optional)      |
-| `rollbar_local_username`     | Local username of deploying user (optional)        |
-| `rollbar_comment`            | Comment for this deployment (optional)             |
-| `rollbar_notification_debug` | `true` to enable notification debugging info       |
-| `rollbar_environment`        | Deployment environment string, defaults to `rails_env` |
+| Name                         | Description                                            |
+| ---------------------------- | ------------------------------------------------------ |
+| `rollbar_access_token`       | Rollbar access token (post_server_item token)          |
+| `rollbar_username`           | Rollbar username of deploying user (optional)          |
+| `rollbar_local_username`     | Local username of deploying user (optional)            |
+| `rollbar_comment`            | Comment for this deployment (optional)                 |
+| `rollbar_env`                | Deployment environment string, defaults to `rails_env` |
 
 ## Contributing
 

--- a/mina-rollbar.gemspec
+++ b/mina-rollbar.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'mina', '~> 1.0.0'
+  spec.add_dependency 'mina', '~> 1.0'
+  spec.add_dependency 'json', '~> 2.1.0'
 
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'bundler', '~> 1.13'


### PR DESCRIPTION
- Removed curl in favor of JSON + Net::HTTP (like the rollbar gem's capistrano implementation)
- Renamed rollbar_environment to rollbar_env to align with other mina env setting names (it's backwards compatible)
- Changed errors to only exit the block, not the entire mina run (exiting is a bit aggressive and could cause weird issues depending on where the notify is in a user's deploy flow)'
- Relaxed mina dependency